### PR TITLE
Add additional flag to allow reconnect after first failed reconnect.

### DIFF
--- a/firmware/main/network/FreeDVReporterTask.h
+++ b/firmware/main/network/FreeDVReporterTask.h
@@ -94,6 +94,7 @@ private:
 
     int pingIntervalMs_;
     int pingTimeoutMs_;
+    bool isConnecting_;
 
     void onReportingSettingsMessage_(DVTask* origin, storage::ReportingSettingsMessage* message);
     void onEnableReportingMessage_(DVTask* origin, EnableReportingMessage* message);

--- a/firmware/sdkconfig
+++ b/firmware/sdkconfig
@@ -1908,15 +1908,15 @@ CONFIG_DSP_MAX_FFT_SIZE=4096
 # end of DSP Library
 
 #
+# libsodium
+#
+# end of libsodium
+
+#
 # ESP WebSocket client
 #
 CONFIG_ESP_WS_CLIENT_ENABLE_DYNAMIC_BUFFER=y
 # end of ESP WebSocket client
-
-#
-# libsodium
-#
-# end of libsodium
 # end of Component config
 
 # CONFIG_IDF_EXPERIMENTAL_FEATURES is not set


### PR DESCRIPTION
This PR fixes an issue discovered where ezDV doesn't try reconnecting again if the first failed reconnection fails. By adding another flag to indicate that the system is attempting to connect, we can trigger the reconnect timer again even if reporting isn't enabled yet.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
