### PR TITLE
Add Kconfig options for various ezDV debugging output.

### DIFF
--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -51,6 +51,9 @@ config EZDV_OUTPUT_TASK_LIST
     help
         Prints a list of executing FreeRTOS tasks.
 
+        NOTE: FreeRTOS tracing options will need to be double-checked after disabling this
+        option as they are forced on even after disabling.
+
 config EZDV_DUMP_TIMERS
     bool "Print timers"
     default n

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -1,0 +1,61 @@
+menu "ezDV Debugging Options"
+
+config EZDV_ENABLE_TICK_OUTPUT
+    bool "Enable per-tick debugging"
+    default n
+    help
+        Enables the printing of periodic debugging output.  This output comes 
+        from the main application task (Application.cpp) and can consist of 
+        one or more types of debugging output that prints every X milliseconds.
+
+        NOTE: this output may impact the performance of executing tasks (especially 
+        anything network-related).
+
+config EZDV_TICK_OUTPUT_INTERVAL
+    int "Debugging output interval (ms)"
+    default 5000
+    depends on EZDV_ENABLE_TICK_OUTPUT
+    help
+        How often to output debugging data to the console in milliseconds.
+
+config EZDV_PRINT_HEAP_USAGE
+    bool "Print heap usage"
+    default n
+    depends on EZDV_ENABLE_TICK_OUTPUT
+    help
+        Outputs the amount of heap remaining in bytes organized by the
+        following categories:
+        * 8 bit allocations
+        * 32 bit allocations
+        * Difference between 32 and 8 bit allocations
+        * Internal RAM
+        * SPIRAM
+        * DMA capable RAM
+
+config EZDV_ENABLE_TX_RX_AUTOMATED_TEST
+    bool "Enable TX/RX toggling"
+    default n
+    depends on EZDV_ENABLE_TICK_OUTPUT
+    help
+        Performs a stress test of the main ezDV code by toggling TX
+        and RX every tick interval. This will also attempt to reset
+        the active FreeDV mode to 700D.
+
+config EZDV_OUTPUT_TASK_LIST
+    bool "Print FreeRTOS task list"
+    default n
+    depends on EZDV_ENABLE_TICK_OUTPUT
+    imply FREERTOS_USE_TRACE_FACILITY
+    imply FREERTOS_GENERATE_RUN_TIME_STATS
+    imply FREERTOS_VTASKLIST_INCLUDE_COREID
+    help
+        Prints a list of executing FreeRTOS tasks.
+
+config EZDV_DUMP_TIMERS
+    bool "Print timers"
+    default n
+    depends on EZDV_ENABLE_TICK_OUTPUT
+    help
+        Prints timer statistics to the console.
+
+endmenu

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -45,9 +45,9 @@ config EZDV_OUTPUT_TASK_LIST
     bool "Print FreeRTOS task list"
     default n
     depends on EZDV_ENABLE_TICK_OUTPUT
-    imply FREERTOS_USE_TRACE_FACILITY
-    imply FREERTOS_GENERATE_RUN_TIME_STATS
-    imply FREERTOS_VTASKLIST_INCLUDE_COREID
+    select FREERTOS_USE_TRACE_FACILITY
+    select FREERTOS_GENERATE_RUN_TIME_STATS
+    select FREERTOS_VTASKLIST_INCLUDE_COREID
     help
         Prints a list of executing FreeRTOS tasks.
 

--- a/firmware/sdkconfig
+++ b/firmware/sdkconfig
@@ -511,6 +511,12 @@ CONFIG_PARTITION_TABLE_MD5=y
 # end of Partition Table
 
 #
+# ezDV Debugging Options
+#
+# CONFIG_EZDV_ENABLE_TICK_OUTPUT is not set
+# end of ezDV Debugging Options
+
+#
 # Compiler options
 #
 CONFIG_COMPILER_OPTIMIZATION_DEBUG=y


### PR DESCRIPTION
Adds Kconfig options for various ezDV debugging output that's currently commented-out. This allows debugging to be enabled without needing to modify the source code.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
