### PR TITLE
Reduces the maximum numbers of messages for some tasks.

### DIFF
--- a/firmware/main/audio/AudioMixer.cpp
+++ b/firmware/main/audio/AudioMixer.cpp
@@ -27,7 +27,7 @@ namespace audio
 {
 
 AudioMixer::AudioMixer()
-    : DVTask("AudioMixer", 15, 3144, tskNO_AFFINITY, pdMS_TO_TICKS(20))
+    : DVTask("AudioMixer", 15, 3144, tskNO_AFFINITY, 16, pdMS_TO_TICKS(20))
     , AudioInput(2, 1)
     , mixerTick_(this, this, &AudioMixer::onTimerTick_, AUDIO_MIXER_TIMER_TICK_US, "AudioMixerTimer")
 {

--- a/firmware/main/audio/BeeperTask.cpp
+++ b/firmware/main/audio/BeeperTask.cpp
@@ -81,7 +81,7 @@ std::map<char, std::string> BeeperTask::CharacterToMorse_ = {
 };
 
 BeeperTask::BeeperTask()
-    : DVTask("BeeperTask", 10, 4096, tskNO_AFFINITY, pdMS_TO_TICKS(10))
+    : DVTask("BeeperTask", 10, 4096, tskNO_AFFINITY, 16, pdMS_TO_TICKS(10))
     , AudioInput(1, 1) // we don't need the input FIFO, just the output one
     , beeperTimer_(this, this, &BeeperTask::onTimerTick_, BEEPER_TIMER_TICK_US, "BeeperTimer")
     , sineGenerator_(CW_SIDETONE_FREQ_HZ, 10000)

--- a/firmware/main/network/flex/FlexTcpTask.cpp
+++ b/firmware/main/network/flex/FlexTcpTask.cpp
@@ -40,7 +40,7 @@ namespace flex
 {
 
 FlexTcpTask::FlexTcpTask()
-    : DVTask("FlexTcpTask", 10, 4096, tskNO_AFFINITY, 128, pdMS_TO_TICKS(10))
+    : DVTask("FlexTcpTask", 10, 4096, tskNO_AFFINITY, 32, pdMS_TO_TICKS(10))
     , reconnectTimer_(this, this, &FlexTcpTask::connect_, MS_TO_US(10000), "FlexTcpReconnectTimer") /* reconnect every 10 seconds */
     , connectionCheckTimer_(this, this, &FlexTcpTask::checkConnection_, MS_TO_US(100), "FlexTcpConnTimer") /* checks for connection every 100ms */
     , commandHandlingTimer_(this, this, &FlexTcpTask::commandResponseTimeout_, MS_TO_US(500), "FlexTcpCmdTimeout") /* time out waiting for command response after 0.5 second */

--- a/firmware/main/network/icom/IcomStateMachine.cpp
+++ b/firmware/main/network/icom/IcomStateMachine.cpp
@@ -83,11 +83,20 @@ void IcomStateMachine::setTheirIdentifier(uint32_t id)
 
 void IcomStateMachine::sendUntracked(IcomPacket& packet)
 {
+    auto task = getTask();
+
+    if (!task->canPostMessage())
+    {
+        // something's gone very wrong, just skip sending the packet
+        // until our queue clears up.
+        return;
+    }
+
     auto allocPacket = new IcomPacket(std::move(packet));
     assert(allocPacket != nullptr);
 
     SendPacketMessage message(allocPacket);
-    getTask()->post(&message);
+    task->post(&message);
 }
 
 void IcomStateMachine::start(std::string ip, uint16_t port, std::string username, std::string password, int localPort)

--- a/firmware/main/task/DVTask.cpp
+++ b/firmware/main/task/DVTask.cpp
@@ -192,6 +192,11 @@ DVTask::MessageEntry* DVTask::createMessageEntry_(DVTask* origin, DVTaskMessage*
     return entry;
 }
 
+bool DVTask::canPostMessage()
+{
+    return uxQueueSpacesAvailable(taskQueue_) > 0;
+}
+
 void DVTask::post(DVTaskMessage* message)
 {
     MessageEntry* entry = createMessageEntry_(nullptr, message);

--- a/firmware/main/task/DVTask.h
+++ b/firmware/main/task/DVTask.h
@@ -63,6 +63,9 @@ public:
     /// @brief Commands the task to perform sleep actions.
     void sleep();
 
+    /// @brief Determines whether there's enough queue space available to post a message.
+    bool canPostMessage();
+
     /// @brief Posts a message to own event queue.
     /// @param message The message to post to the task.
     void post(DVTaskMessage* message);


### PR DESCRIPTION
This reduces the amount of internal RAM that ezDV allocates, but also requires additional protection to ensure we don't overflow queues (i.e. when sending packets on congested Wi-Fi networks). Such protection is also included in this PR.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
