### PR TITLE
Only kill websocket task when ezDV is sleeping.

### DIFF
--- a/firmware/main/network/FreeDVReporterTask.cpp
+++ b/firmware/main/network/FreeDVReporterTask.cpp
@@ -90,7 +90,7 @@ void FreeDVReporterTask::onTaskSleep_()
 {
     if (reportingEnabled_)
     {
-        stopSocketIoConnection_();
+        stopSocketIoConnection_(true);
     }
 
     reconnectTimer_.stop();
@@ -424,7 +424,7 @@ void FreeDVReporterTask::handleSocketIoMessage_(char* ptr, int length)
     }
 }
 
-void FreeDVReporterTask::stopSocketIoConnection_()
+void FreeDVReporterTask::stopSocketIoConnection_(bool isSleeping)
 {
     ESP_LOGI(CURRENT_LOG_TAG, "stopping socket.io connection");
     if (reportingClientHandle_ != nullptr)
@@ -436,36 +436,39 @@ void FreeDVReporterTask::stopSocketIoConnection_()
             esp_websocket_client_stop(reportingClientHandle_);
         }
         
-        // XXX - there's a bug in esp_websocket_client that causes it to take a while to
-        // destroy its task after stopping the client. While not ideal, the below code
-        // to check for this process and close it at least prevents it from accessing
-        // invalid memory if it were to stay running after destroying the handle.
-        auto websocketHandle = xTaskGetHandle("websocket_task");
-        if (websocketHandle != nullptr)
+        if (isSleeping)
         {
-            ESP_LOGW(CURRENT_LOG_TAG, "websocket_task is still running despite esp_websocket_client_stop()!");
-        }
-        auto timeBegin = esp_timer_get_time();
-        bool forceKillTask = false;
-        while (websocketHandle != nullptr)
-        {
-            auto currentState = eTaskGetState(websocketHandle);
-            auto timeElapsed = esp_timer_get_time() - timeBegin;
-            if (currentState == eDeleted || currentState == eInvalid ||
-                timeElapsed >= MS_TO_US(1000))
+            // XXX - there's a bug in esp_websocket_client that causes it to take a while to
+            // destroy its task after stopping the client. While not ideal, the below code
+            // to check for this process and close it at least prevents it from accessing
+            // invalid memory if it were to stay running after destroying the handle.
+            auto websocketHandle = xTaskGetHandle("websocket_task");
+            if (websocketHandle != nullptr)
             {
-                forceKillTask = timeElapsed >= MS_TO_US(1000);
-                break;
+                ESP_LOGW(CURRENT_LOG_TAG, "websocket_task is still running despite esp_websocket_client_stop()!");
+            }
+            auto timeBegin = esp_timer_get_time();
+            bool forceKillTask = false;
+            while (websocketHandle != nullptr)
+            {
+                auto currentState = eTaskGetState(websocketHandle);
+                auto timeElapsed = esp_timer_get_time() - timeBegin;
+                if (currentState == eDeleted || currentState == eInvalid ||
+                    timeElapsed >= MS_TO_US(1000))
+                {
+                    forceKillTask = timeElapsed >= MS_TO_US(1000);
+                    break;
+                }
+
+                // Make sure other stuff can run.
+                taskYIELD();
             }
 
-            // Make sure other stuff can run.
-            taskYIELD();
-        }
-
-        if (forceKillTask && websocketHandle != nullptr)
-        {
-            ESP_LOGI(CURRENT_LOG_TAG, "More than 1000ms has elapsed waiting for websocket_task, force killing it now.");
-            vTaskDelete(websocketHandle);
+            if (forceKillTask && websocketHandle != nullptr)
+            {
+                ESP_LOGI(CURRENT_LOG_TAG, "More than 1000ms has elapsed waiting for websocket_task, force killing it now.");
+                vTaskDelete(websocketHandle);
+            }
         }
         
         esp_websocket_client_destroy(reportingClientHandle_);

--- a/firmware/main/network/FreeDVReporterTask.h
+++ b/firmware/main/network/FreeDVReporterTask.h
@@ -111,7 +111,7 @@ private:
     const char* freeDVModeAsString_();
 
     void startSocketIoConnection_(DVTimer*);
-    void stopSocketIoConnection_();
+    void stopSocketIoConnection_(bool isSleeping = false);
     void handleEngineIoMessage_(char* ptr, int length);
     void handleSocketIoMessage_(char* ptr, int length);
 


### PR DESCRIPTION
Partially suppresses a previous fix for 1.0.2 that kills the websocket task when `FreeDVReporterTask` was attempting to disconnect from FreeDV Reporter by having this fix only happen when ezDV is shutting down.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
