### PR TITLE
Update esp_websocket_client to version 1.2.3.

### DIFF
--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   espressif/libsodium: "*"
   ## Required IDF version
   idf:
-    version: ">=4.1.0"
+    version: ">=5.2.1"
   # # Put list of dependencies here
   # # For components maintained by Espressif:
   # component: "~1.0.0"

--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -1,6 +1,6 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp_websocket_client: "*"
+  espressif/esp_websocket_client: ">=1.2.3"
   espressif/libsodium: "*"
   ## Required IDF version
   idf:

--- a/firmware/main/network/FreeDVReporterTask.h
+++ b/firmware/main/network/FreeDVReporterTask.h
@@ -111,7 +111,7 @@ private:
     const char* freeDVModeAsString_();
 
     void startSocketIoConnection_(DVTimer*);
-    void stopSocketIoConnection_(bool isSleeping = false);
+    void stopSocketIoConnection_();
     void handleEngineIoMessage_(char* ptr, int length);
     void handleSocketIoMessage_(char* ptr, int length);
 

--- a/firmware/main/network/WirelessTask.cpp
+++ b/firmware/main/network/WirelessTask.cpp
@@ -205,7 +205,7 @@ void WirelessTask::onTaskSleep_()
     // Stop reporting
     if (freeDVReporterTask_.isAwake())
     {
-        sleep(&freeDVReporterTask_, pdMS_TO_TICKS(1000));
+        sleep(&freeDVReporterTask_, pdMS_TO_TICKS(2000));
     }
 
     disableHttp_();


### PR DESCRIPTION
Upgrades esp_websocket_client to version 1.2.3 and adjusts previous workaround to take the fix in that version into account.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
