### PR TITLE
Update manual and web UI to refer to Flex 8000 series radios.

### DIFF
--- a/firmware/main/http_server_files/index.html.in
+++ b/firmware/main/http_server_files/index.html.in
@@ -408,7 +408,7 @@
                     <div class="col-xs-8 col-md-4">
                     <select id="radioType" class="form-control">
                         <option value="0">Icom (e.g. IC-705)</option>
-                        <option value="1">Flex 6000 series</option>
+                        <option value="1">Flex 6000/8000 series</option>
                     </select>
                     </div>
                 </div>

--- a/firmware/main/network/flex/FlexTcpTask.h
+++ b/firmware/main/network/flex/FlexTcpTask.h
@@ -41,7 +41,7 @@ namespace flex
 
 using namespace ezdv::task;
 
-/// @brief Handles the main TCP/IP socket for Flex 6000 series radios.
+/// @brief Handles the main TCP/IP socket for Flex 6000/8000 series radios.
 class FlexTcpTask : public DVTask
 {
 public:

--- a/firmware/main/network/flex/FlexVitaTask.h
+++ b/firmware/main/network/flex/FlexVitaTask.h
@@ -45,7 +45,7 @@ namespace flex
 
 using namespace ezdv::task;
 
-/// @brief Handles the VITA UDP socket for Flex 6000 series radios.
+/// @brief Handles the VITA UDP socket for Flex 6000/8000 series radios.
 class FlexVitaTask : public DVTask, public audio::AudioInput
 {
 public:

--- a/firmware/main/network/flex/SampleRateConverter.h
+++ b/firmware/main/network/flex/SampleRateConverter.h
@@ -30,7 +30,7 @@ extern "C" {
 #define FDMDV_FLOAT_TO_SHORT    ((float)32767.0)                /* Multiplication factor to convert float between -1.0 and 1.0 to short */
 #define FDMDV_SHORT_TO_FLOAT    ((float)1.0 / FDMDV_FLOAT_TO_SHORT) /* Multiplication factor to convert short between -32768 and 32767 to float */
 
-/* Special purpose 8->24K conversion functions for the Flex 6000 series.
+/* Special purpose 8->24K conversion functions for the Flex 6000/8000 series.
    The Flex uses floating point numbers while Codec2 uses shorts, so we
    also have code to convert between those formats. */
 void           fdmdv_8_to_24_with_scaling(float out24k[], short in8k[], int n, float scaleFactor);

--- a/manual/2-setting-up-ezdv.md
+++ b/manual/2-setting-up-ezdv.md
@@ -63,10 +63,10 @@ section.
 ### Radios with Wi-Fi support
 
 If you have a radio that is capable of remote network access, you can configure ezDV to connect to the radio
-over Wi-Fi. Currently this is supported only for the [FlexRadio](https://www.flexradio.com/) 6000 series radios 
+over Wi-Fi. Currently this is supported only for the [FlexRadio](https://www.flexradio.com/) 6000/8000 series radios 
 and the Icom IC-705.
 
-#### Flex 6000 series radios
+#### Flex 6000/8000 series radios
 
 Ensure that you can access your radio using the SmartSDR software from a PC on the same network (i.e. *not* using SmartLink).
 Once this is confirmed, skip to [Initial Configuration](#initial-configuration).
@@ -91,9 +91,9 @@ Once joined, open your Web browser and navigate to http://192.168.4.1/. You shou
 
 ### Transmit audio levels
 
-#### Flex 6000 series
+#### Flex 6000/8000 series
 
-ezDV uses a hardcoded transmit level when connected to the Flex 6000 series of radios, so adjusting the transmit level on 
+ezDV uses a hardcoded transmit level when connected to the Flex 6000/8000 series of radios, so adjusting the transmit level on 
 ezDV has no effect.
 
 #### Other radios
@@ -135,7 +135,7 @@ this name instead of trying to find its IP address. Click or tap Save to save yo
 Click on the "Radio" tab and check the "Use Wi-Fi Network for Radio RX/TX" checkbox. Select your radio model in the "Radio Type"
 drop-down list, which will bring up different fields depending on the radio being configured.
 
-#### Flex 6000 series
+#### Flex 6000/8000 series
 
 Select the name of your radio from the "Radio" drop-down list as shown below. Your radio's IP address should automatically
 be filled in the "IP Address" field:
@@ -180,7 +180,7 @@ as shown below:
 
 ![Icom IC-705 properly connected to ezDV (WLAN indicator at the top of the screen)](images/2-setup-radio-ic705-connected.jpg)
 
-For Flex 6000 series radios, opening the SmartSDR software will show a "FDVU" (for upper sideband) and "FDVL" (for lower sideband) mode if ezDV is properly connected
+For Flex 6000/8000 series radios, opening the SmartSDR software will show a "FDVU" (for upper sideband) and "FDVL" (for lower sideband) mode if ezDV is properly connected
 to the radio:
 
 ![Flex 6300 properly connected to ezDV (existence of FDVU/FDVL modes)](images/2-setup-radio-flex-connected.png)

--- a/manual/3-basic-usage.md
+++ b/manual/3-basic-usage.md
@@ -58,7 +58,7 @@ pushing and releasing the call button will toggle between transmit and receive.
 
 ## Radio setup and usage
 
-### Flex 6000 series
+### Flex 6000/8000 series
 
 To use ezDV, simply start the SmartSDR software on your PC or iPad and select either FDVU mode (for upper sideband) 
 or FDVL (for lower sideband). Decoded audio as well as Morse code beeps will be output to your speaker. Use the MOX
@@ -86,7 +86,7 @@ times configured (with it pausing a configured number of seconds). By default, e
 the voice keyer file up to ten times, pausing for five seconds in between each transmission.
 
 While the voice keyer is active, pressing any button on ezDV will stop the voice keyer and place it back into
-regular operation. If using a Flex 6000 series radio, you can also stop the voice keyer by pushing the MOX button
+regular operation. If using a Flex 6000/8000 series radio, you can also stop the voice keyer by pushing the MOX button
 in SmartSDR
 
 Configuration of the voice keyer functionality (as well as stopping and starting of the voice keyer) can also be 

--- a/manual/4-using-the-web-interface.md
+++ b/manual/4-using-the-web-interface.md
@@ -142,7 +142,7 @@ Pushing Save here will save these settings to ezDV's internal flash but require 
 ## Configuring radio connection and headset
 
 The Radio tab allows configuration of ezDV's connection to a network-enabled radio as well as headset-related functions. 
-Currently ezDV supports connections to the Icom IC-705 and Flex 6000 series radios, as shown below:
+Currently ezDV supports connections to the Icom IC-705 and Flex 6000/8000 series radios, as shown below:
 
 ![ezDV showing a FlexRadio configuration](images/2-setup-webpage-radio-flex.png)
 
@@ -155,7 +155,7 @@ The following can be configured in this screen:
 | Enable PTT using headset button | Enables the usage of the "call" button on your wired headset for toggling PTT. (See [Basic usage](#basic-usage)" for more information.) |
 | Time Out Timer (seconds) | Configures ezDV's "time out timer", which automatically puts the radio back into receive if the radio is stuck in transmit mode for too long. |
 | Use Wi-Fi Network for Radio RX/TX | When checked, allows ezDV to connect to a supported radio over Wi-Fi instead of using a wired headset. |
-| Radio Type | The type of radio that ezDV should connect to. This can be either "Flex 6000 series" or "Icom (e.g. IC-705)". Relevant settings for each radio type will appear in this tab as appropriate. |
+| Radio Type | The type of radio that ezDV should connect to. This can be either "Flex 6000/8000 series" or "Icom (e.g. IC-705)". Relevant settings for each radio type will appear in this tab as appropriate. |
 | Radio | Displays the list of Flex radios that ezDV is able to see on the network. You can also choose "(other)" and manually enter its IP address. |
 | IP Address | For Flex radios, this is typically auto-filled when selecting a radio from the Radio list. Otherwise, this is the IP address of the radio which to connect to. |
 | Port | For the IC-705, this is the control port number of the built-in server running on the radio. Defaults to "50001" and should not normally need to be changed. |


### PR DESCRIPTION
Adds references to Flex 8000 series to resolve #41.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
