### PR TITLE
[IC-705] Optimize socket and audio handling

### DIFF
--- a/firmware/main/network/icom/AudioState.h
+++ b/firmware/main/network/icom/AudioState.h
@@ -52,7 +52,7 @@ private:
     DVTimer audioWatchdogTimer_;
     uint16_t audioSequenceNumber_;
     bool completingTransmit_;
-    float audioMultiplier_[160];
+    short audioMultiplier_[160]; // Q5.11 fixed point
 
     void onAudioOutTimer_(DVTimer*);
     void onAudioWatchdog_(DVTimer*);

--- a/firmware/main/network/icom/IcomStateMachine.cpp
+++ b/firmware/main/network/icom/IcomStateMachine.cpp
@@ -177,10 +177,14 @@ void IcomStateMachine::openSocket_()
     }
     assert(rv != -1);
     
+    // Initialize Wi-Fi prioritization
     const int precedenceVI = 6;
     const int precedenceOffset = 7;
     int priority = (precedenceVI << precedenceOffset);
     setsockopt(socket_, IPPROTO_IP, IP_TOS, &priority, sizeof(priority));
+
+    // Use non-blocking sockets
+    fcntl(socket_, F_SETFL, O_NONBLOCK);
 }
 
 void IcomStateMachine::onTransitionComplete_()
@@ -208,32 +212,18 @@ void IcomStateMachine::readPendingPackets_(DVTimer*)
     {
         return;
     }
-    
-    fd_set readSet;
-    struct timeval tv = {0, 0};
-    
-    FD_ZERO(&readSet);
-    FD_SET(socket_, &readSet);
-    
+       
     // Process if there are pending datagrams in the buffer
-    if (select(socket_ + 1, &readSet, nullptr, nullptr, &tv) > 0)
+    char buffer[MAX_PACKET_SIZE];
+    auto rv = recv(socket_, buffer, MAX_PACKET_SIZE, 0);
+    if (rv > 0)
     {
-        char buffer[MAX_PACKET_SIZE];
-        
-        auto rv = recv(socket_, buffer, MAX_PACKET_SIZE, 0);
-        if (rv > 0)
-        {
-            auto packet = new IcomPacket(buffer, rv);
-            assert(packet != nullptr);
+        auto packet = new IcomPacket(buffer, rv);
+        assert(packet != nullptr);
 
-            // Queue up packet for future processing.
-            ReceivePacketMessage message(packet);
-            getTask()->post(&message);
-        }
-        
-        // Reinitialize the read set for the next pass.
-        FD_ZERO(&readSet);
-        FD_SET(socket_, &readSet);
+        // Queue up packet for future processing.
+        ReceivePacketMessage message(packet);
+        getTask()->post(&message);
     }
 }
 

--- a/firmware/sdkconfig
+++ b/firmware/sdkconfig
@@ -1913,15 +1913,15 @@ CONFIG_DSP_MAX_FFT_SIZE=4096
 # end of DSP Library
 
 #
-# libsodium
-#
-# end of libsodium
-
-#
 # ESP WebSocket client
 #
 CONFIG_ESP_WS_CLIENT_ENABLE_DYNAMIC_BUFFER=y
 # end of ESP WebSocket client
+
+#
+# libsodium
+#
+# end of libsodium
 # end of Component config
 
 # CONFIG_IDF_EXPERIMENTAL_FEATURES is not set


### PR DESCRIPTION
Performs several optimizations to reduce the CPU usage required for IC-705 support:

1. Use non-blocking sockets instead of `select()` (similar to what was previously done in #33 for FlexRadio support).
2. Use fixed-point math to amplify TX audio going to the IC-705 (to take advantage of integer-only SIMD instructions on the ESP32-S3 and slightly reduce stack consumption).

Benchmark results:

*1.0.3 RX:*

```
| Task | Run Time | Percentage
| IcomSocketTask/ | 119517 | 5%
| IcomSocketTask/ | 121203 | 6%
| IcomSocketTask/ | 57806 | 2%
```

*1.0.3 TX:*

```
| Task | Run Time | Percentage
| IcomSocketTask/ | 142365 | 7%
| IcomSocketTask/ | 59905 | 2%
| IcomSocketTask/ | 97499 | 4%
```

*PR RX:*

```
| Task | Run Time | Percentage
| IcomSocketTask/ | 16438 | 0%
| IcomSocketTask/ | 35090 | 1%
| IcomSocketTask/ | 25191 | 1%
```

*PR TX:*

```
| Task | Run Time | Percentage
| IcomSocketTask/ | 23805 | 1%
| IcomSocketTask/ | 50360 | 2%
| IcomSocketTask/ | 18416 | 0%
```

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
