### PR TITLE
Change underlying mode for FreeDV LSB to DIGL

### DIFF
--- a/firmware/main/network/flex/FlexTcpTask.cpp
+++ b/firmware/main/network/flex/FlexTcpTask.cpp
@@ -287,7 +287,7 @@ void FlexTcpTask::initializeWaveform_()
     // Send needed commands to initialize the waveform. This is from the reference
     // waveform implementation.
     createWaveform_("FreeDV-USB", "FDVU", "DIGU");
-    createWaveform_("FreeDV-LSB", "FDVL", "LSB");
+    createWaveform_("FreeDV-LSB", "FDVL", "DIGL");
     
     // subscribe to slice updates, needed to detect when we enter FDVU/FDVL mode
     sendRadioCommand_("sub slice all");


### PR DESCRIPTION
The underlying mode should be DIGL for LSB similar to how it is DIGU for USB.  This will disable any audio processing including CESSB and TX equalization that could corrupt the waveform.

---

## Before merging:

- [ ] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
