### PR TITLE
Flex: fix issue where changing to FDVL does not properly update filter.

### DIFF
--- a/firmware/main/network/flex/FlexTcpTask.cpp
+++ b/firmware/main/network/flex/FlexTcpTask.cpp
@@ -570,16 +570,16 @@ void FlexTcpTask::processCommand_(std::string& command)
 
                         // User wants to use the waveform.
                         activeSlice_ = sliceId;
-                        isLSB_ = mode->second == "FDVL";
-
-                        // Set the filter corresponding to the current mode.
-                        setFilter_(currentWidth_.first, currentWidth_.second);
 
                         // Ensure that we connect to any reporting services as appropriate
                         uint64_t freqHz = atof(sliceFrequencies_[activeSlice_].c_str()) * 1000000;
                         ReportFrequencyChangeMessage freqChangeMessage(freqHz);
                         publish(&freqChangeMessage);
                     }
+                    
+                    // Set the filter corresponding to the current mode.
+                    isLSB_ = mode->second == "FDVL";
+                    setFilter_(currentWidth_.first, currentWidth_.second);
                 }
                 else if (sliceId == activeSlice_)
                 {


### PR DESCRIPTION
When using ezDV with a Flex radio and the user changes into FDVL mode from FDVU, ezDV does not correctly set filters. That is, the filters are still set based on upper sideband and not lower sideband. This PR resolves this bug by forcing a filter change whenever the radio sends the mode of the current slice.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
