### PR TITLE
Fix memory leak in FreeDV Reporter code when sending JSON to server.

### DIFF
--- a/firmware/main/network/FreeDVReporterTask.cpp
+++ b/firmware/main/network/FreeDVReporterTask.cpp
@@ -213,7 +213,7 @@ void FreeDVReporterTask::onFreeDVCallsignReceivedMessage_(DVTask* origin, audio:
         esp_websocket_client_send_text(reportingClientHandle_, messageToSend.c_str(), messageToSend.length(), portMAX_DELAY);
 
         cJSON_free(tmp);
-        cJSON_Delete(messagePayload);        
+        cJSON_Delete(message);        
     }
 }
 

--- a/firmware/main/network/FreeDVReporterTask.cpp
+++ b/firmware/main/network/FreeDVReporterTask.cpp
@@ -213,7 +213,7 @@ void FreeDVReporterTask::onFreeDVCallsignReceivedMessage_(DVTask* origin, audio:
         esp_websocket_client_send_text(reportingClientHandle_, messageToSend.c_str(), messageToSend.length(), portMAX_DELAY);
 
         cJSON_free(tmp);
-        cJSON_Delete(message);        
+        cJSON_Delete(outMessage);        
     }
 }
 

--- a/firmware/main/network/FreeDVReporterTask.cpp
+++ b/firmware/main/network/FreeDVReporterTask.cpp
@@ -507,7 +507,7 @@ void FreeDVReporterTask::sendReportingMessageUpdate_()
     esp_websocket_client_send_text(reportingClientHandle_, messageToSend.c_str(), messageToSend.length(), portMAX_DELAY);
 
     cJSON_free(tmp);
-    cJSON_Delete(messagePayload);
+    cJSON_Delete(message);
 }
 
 void FreeDVReporterTask::sendFrequencyUpdate_()
@@ -537,7 +537,7 @@ void FreeDVReporterTask::sendFrequencyUpdate_()
     esp_websocket_client_send_text(reportingClientHandle_, messageToSend.c_str(), messageToSend.length(), portMAX_DELAY);
 
     cJSON_free(tmp);
-    cJSON_Delete(messagePayload);
+    cJSON_Delete(message);
 }
 
 void FreeDVReporterTask::sendTransmitStateUpdate_()
@@ -571,7 +571,7 @@ void FreeDVReporterTask::sendTransmitStateUpdate_()
     esp_websocket_client_send_text(reportingClientHandle_, messageToSend.c_str(), messageToSend.length(), portMAX_DELAY);
 
     cJSON_free(tmp);
-    cJSON_Delete(messagePayload);
+    cJSON_Delete(message);
 }
 
 void FreeDVReporterTask::WebsocketEventHandler_(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data)


### PR DESCRIPTION
While working on #50, it was discovered that with IC-705 support turned on, ezDV crashes extremely quickly after the Icom tasks start up. Further investigation of this issue resulted in the discovery that internal RAM usage was decreasing every time ezDV reported to FreeDV Reporter (for example, during frequency changes). 

The root cause of this is that we were deleting the message payload and not the entire message. Updating the code to delete the entire message instead results in internal RAM usage remaining relatively constant (depending on what the system is doing).

---

## Before merging:

- [ ] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
