### PR TITLE
Shave a few more bytes of RAM usage.

### DIFF
--- a/firmware/main/network/FreeDVReporterTask.cpp
+++ b/firmware/main/network/FreeDVReporterTask.cpp
@@ -38,7 +38,7 @@ namespace network
 {
 
 FreeDVReporterTask::FreeDVReporterTask()
-    : ezdv::task::DVTask("FreeDVReporterTask", 1, 4096, tskNO_AFFINITY, 128)
+    : ezdv::task::DVTask("FreeDVReporterTask", 1, 3072, tskNO_AFFINITY, 32)
     , reconnectTimer_(this, this, &FreeDVReporterTask::startSocketIoConnection_, MS_TO_US(10000), "FDVReporterReconn")
     , reportingClientHandle_(nullptr)
     , jsonAuthObj_(nullptr)

--- a/firmware/main/network/PskReporterTask.cpp
+++ b/firmware/main/network/PskReporterTask.cpp
@@ -65,7 +65,7 @@ namespace network
 {
 
 PskReporterTask::PskReporterTask()
-    : ezdv::task::DVTask("PskReporterTask", 1, 4096, tskNO_AFFINITY, 128)
+    : ezdv::task::DVTask("PskReporterTask", 1, 3072, tskNO_AFFINITY, 32)
     , udpSendTimer_(this, this, &PskReporterTask::sendPskReporterRecords_, MS_TO_US(PSK_REPORTER_SEND_INTERVAL_MS), "PskReporterReconn")
     , reportingEnabled_(false)
     , callsign_("")

--- a/firmware/main/network/icom/IcomSocketTask.cpp
+++ b/firmware/main/network/icom/IcomSocketTask.cpp
@@ -34,7 +34,7 @@ IcomSocketTask::IcomSocketTask(SocketType socketType)
     : DVTask(
         GetTaskName_(socketType), 
         (socketType == AUDIO_SOCKET) ? 16 : 10, 
-        4096, 
+        3500, 
         (socketType == AUDIO_SOCKET) ? 1 : tskNO_AFFINITY, 
         (socketType == AUDIO_SOCKET) ? 512 : 256, pdMS_TO_TICKS(20))
     , ezdv::audio::AudioInput(1, 1)


### PR DESCRIPTION
Shaves a few more bytes of internal RAM usage so that we have more headroom for stuff like Ethernet (#50).

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
