### PR TITLE
Add System Status tab and display basic FreeDV stats.

### DIFF
--- a/firmware/main/audio/FreeDVMessage.h
+++ b/firmware/main/audio/FreeDVMessage.h
@@ -51,13 +51,15 @@ enum FreeDVMessageTypes
 class FreeDVSyncStateMessage : public DVTaskMessageBase<SYNC_STATE, FreeDVSyncStateMessage>
 {
 public:
-    FreeDVSyncStateMessage(bool syncStateProvided = false)
+    FreeDVSyncStateMessage(bool syncStateProvided = false, int freqOffsetProvided = 0)
         : DVTaskMessageBase<SYNC_STATE, FreeDVSyncStateMessage>(FREEDV_MESSAGE)
         , syncState(syncStateProvided)
+        , freqOffset(freqOffsetProvided)
         {}
     virtual ~FreeDVSyncStateMessage() = default;
 
     bool syncState;
+    int freqOffset;
 };
 
 enum FreeDVMode

--- a/firmware/main/audio/FreeDVTask.cpp
+++ b/firmware/main/audio/FreeDVTask.cpp
@@ -94,6 +94,7 @@ void FreeDVTask::onTaskTick_()
     if (!isActive_) return;
 
     bool syncLed = false;
+    int freqOffset = 0;
 
     //ESP_LOGI(CURRENT_LOG_TAG, "timer tick");
 
@@ -201,11 +202,14 @@ void FreeDVTask::onTaskTick_()
             }
         
             syncLed = freedv_get_sync(dv_) > 0;
+            
+            freedv_get_modem_extended_stats(dv_, stats_);
+            freqOffset = stats_->foff;
         }
     }
 
     // Broadcast current sync state
-    FreeDVSyncStateMessage* message = new FreeDVSyncStateMessage(syncLed);
+    FreeDVSyncStateMessage* message = new FreeDVSyncStateMessage(syncLed, freqOffset);
     publish(message);
     delete message;
 }

--- a/firmware/main/http_server_files/index.html.in
+++ b/firmware/main/http_server_files/index.html.in
@@ -59,6 +59,9 @@
                     <li class="nav-item">
                         <button id="updateTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#updateTabForm" aria-current="page-update">Firmware Update</button>
                     </li>
+                    <li class="nav-item">
+                        <button id="statusTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#statusTabForm" aria-current="page-status">System Status</button>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -251,6 +254,17 @@
                     <button type="reset" class="btn btn-danger" id="updateReset">Reset</button>
                     </div>
                     <div class="col-8">&nbsp;</div>
+                </div>
+            </form>
+            <form class="tab-pane fade show" id="statusTabForm">
+                <div class="table-responsive">
+                  <table class="table">
+                    <tbody>
+                      <tr><th colspan="2">FreeDV Signal</th></tr>
+                      <tr><td>Synced</td><td id="syncState">No</td></tr>
+                      <tr><td>Frequency offset</td><td id="freqOffset">0</td></tr>
+                    </tbody>
+                  </table>
                 </div>
             </form>
             <form class="tab-pane fade" id="wifiTabForm">

--- a/firmware/main/http_server_files/localscript.js
+++ b/firmware/main/http_server_files/localscript.js
@@ -523,6 +523,19 @@ function wsConnect()
             $("#startVoiceKeyer").removeClass("btn-danger");
           }
       }
+      else if (json.type == "freedvStatus")
+      {
+          if (json.sync)
+          {
+              $("#syncState").text("Yes");
+          }
+          else
+          {
+              $("#syncState").text("No");
+          }
+          
+          $("#freqOffset").text(json.freqOffset);
+      }
   };
 
   ws.onclose = function(e) 

--- a/firmware/main/network/HttpServerTask.h
+++ b/firmware/main/network/HttpServerTask.h
@@ -19,6 +19,7 @@
 #define HTTP_SERVER_TASK_H
 
 #include <vector>
+#include <deque>
 
 #include "esp_event.h"
 #include "esp_http_server.h"
@@ -140,6 +141,10 @@ private:
     WebSocketList activeWebSockets_;
     bool isRunning_;
     
+    std::deque<int> freqOffsets_;
+    int currFreqOffset_;
+    int freqOffsetCount_;
+    
     void onHttpWebsocketConnectedMessage_(DVTask* origin, HttpWebsocketConnectedMessage* message);
     void onHttpWebsocketDisconnectedMessage_(DVTask* origin, HttpWebsocketDisconnectedMessage* message);
     
@@ -169,6 +174,9 @@ private:
     void onStartWifiScanMessage_(DVTask* origin, HttpServerTask::StartWifiScanMessage* message);
     void onStopWifiScanMessage_(DVTask* origin, HttpServerTask::StopWifiScanMessage* message);
     void onWifiNetworkListMessage_(DVTask* origin, WifiNetworkListMessage* message);
+    
+    // FreeDV sync state reporting
+    void onFreeDVSyncStateMessage_(DVTask* origin, audio::FreeDVSyncStateMessage* message);
 
     // Helper to asynchronously serve static files.
     void onHttpServeStaticFileMessage_(DVTask* origin, HttpServeStaticFileMessage* message);


### PR DESCRIPTION
This PR adds a tab to the web interface called "System Status" that currently displays the following FreeDV statistics:

* Sync status
* Frequency offset (TBD: Codec2 bug is preventing this from working)
* SNR (TBD)

---

## Before merging:

- [ ] All CI actions must build without errors.
- [ ] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
