### PR TITLE
Update project to use ESP-IDF v5.3.

### DIFF
--- a/.github/workflows/build_ezdv.yml
+++ b/.github/workflows/build_ezdv.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install ESP-IDF
         shell: bash
         run: |
-          git clone -b v5.2.2 --recursive https://github.com/espressif/esp-idf.git
+          git clone -b v5.3 --recursive https://github.com/espressif/esp-idf.git
           cd esp-idf
           ./install.sh all
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ general use and operation.
 
 ## Building the firmware
 
-Install [ESP-IDF v5.2.1](https://docs.espressif.com/projects/esp-idf/en/v5.2.1/esp32s3/get-started/index.html) and then run the following:
+Install [ESP-IDF v5.3](https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32s3/get-started/index.html) and then run the following:
 
 ```
 . /path/to/esp-idf/export.sh

--- a/firmware/main/idf_component.yml
+++ b/firmware/main/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   espressif/libsodium: "*"
   ## Required IDF version
   idf:
-    version: ">=5.2.2"
+    version: ">=5.3"
   # # Put list of dependencies here
   # # For components maintained by Espressif:
   # component: "~1.0.0"


### PR DESCRIPTION
Updates firmware to use ESP-IDF v5.3. This ensures we have the latest bugfixes and features from Espressif.

---

## Before merging:

- [x] All CI actions must build without errors.
- [x] If the PR adds new user-facing functionality, this must be documented in the [user guide](https://tmiw.github.io/ezDV/). The Markdown files in the `manual` folder should be modified for this purpose.
